### PR TITLE
Code cleaning and documentation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -155,9 +155,9 @@ pub struct Message {
     /// Message `OneOf`s
     pub oneofs: Vec<OneOf>,
     /// Message reserved numbers
-    pub reserved_nums: Option<Vec<i32>>,
+    pub reserved_nums: Vec<i32>,
     /// Message reserved names
-    pub reserved_names: Option<Vec<String>>,
+    pub reserved_names: Vec<String>,
     /// Nested messages
     pub messages: Vec<Message>,
     /// Nested enums

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ extern crate nom;
 mod parser;
 
 use std::path::PathBuf;
+use std::ops::Range;
 use parser::file_descriptor;
 
 /// Protobox syntax
@@ -155,7 +156,7 @@ pub struct Message {
     /// Message `OneOf`s
     pub oneofs: Vec<OneOf>,
     /// Message reserved numbers
-    pub reserved_nums: Vec<i32>,
+    pub reserved_nums: Vec<Range<i32>>,
     /// Message reserved names
     pub reserved_names: Vec<String>,
     /// Nested messages

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,8 @@
+//! A nom-based protobuf file parser
+//!
+//! This crate can be seen as a rust transcription of the
+//! [descriptor.proto](https://github.com/google/protobuf/blob/master/src/google/protobuf/descriptor.proto) file
+
 #[macro_use]
 extern crate nom;
 
@@ -162,25 +167,25 @@ pub struct Message {
     /// Nested messages
     pub messages: Vec<Message>,
     /// Nested enums
-    pub enums: Vec<Enumerator>,
+    pub enums: Vec<Enumeration>,
 }
 
-/// A protobuf enumerator field
+/// A protobuf enumeration field
 #[derive(Debug, Clone)]
-pub struct EnumVariant {
-    /// enum variant name
+pub struct EnumValue {
+    /// enum value name
     pub name: String,
-    /// enum variant number
+    /// enum value number
     pub number: i32,
 }
 
 /// A protobuf enumerator
 #[derive(Debug, Clone)]
-pub struct Enumerator {
+pub struct Enumeration {
     /// enum name
     pub name: String,
-    /// enum variants
-    pub variants: Vec<EnumVariant>,
+    /// enum values
+    pub values: Vec<EnumValue>,
 }
 
 /// A OneOf
@@ -204,7 +209,7 @@ pub struct FileDescriptor {
     /// Top level messages
     pub messages: Vec<Message>,
     /// Enums
-    pub enums: Vec<Enumerator>,
+    pub enums: Vec<Enumeration>,
 }
 
 impl FileDescriptor {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,13 +1,17 @@
-#[macro_use] extern crate nom;
+#[macro_use]
+extern crate nom;
 
 mod parser;
 
 use std::path::PathBuf;
 use parser::file_descriptor;
 
+/// Protobox syntax
 #[derive(Debug, Clone, Copy)]
 pub enum Syntax {
+    /// Protobuf syntax [2](https://developers.google.com/protocol-buffers/docs/proto) (default)
     Proto2,
+    /// Protobuf syntax [3](https://developers.google.com/protocol-buffers/docs/proto3)
     Proto3,
 }
 
@@ -17,87 +21,189 @@ impl Default for Syntax {
     }
 }
 
+/// A field frequency
 #[derive(Debug, Clone)]
 pub enum Frequency {
+    /// A well-formed message can have zero or one of this field (but not more than one).
     Optional,
+    /// This field can be repeated any number of times (including zero) in a well-formed message.
+    /// The order of the repeated values will be preserved.
     Repeated,
+    /// A well-formed message must have exactly one of this field.
     Required,
 }
 
+/// Protobuf supported field types
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum FieldType {
+    /// Protobuf int32
+    ///
+    /// # Remarks
+    ///
+    /// Uses variable-length encoding. Inefficient for encoding negative numbers – if
+    /// your field is likely to have negative values, use sint32 instead.
     Int32,
+    /// Protobuf int64
+    ///
+    /// # Remarks
+    ///
+    /// Uses variable-length encoding. Inefficient for encoding negative numbers – if
+    /// your field is likely to have negative values, use sint64 instead.
     Int64,
+    /// Protobuf uint32
+    ///
+    /// # Remarks
+    ///
+    /// Uses variable-length encoding.
     Uint32,
+    /// Protobuf uint64
+    ///
+    /// # Remarks
+    ///
+    /// Uses variable-length encoding.
     Uint64,
+    /// Protobuf sint32
+    ///
+    /// # Remarks
+    ///
+    /// Uses variable-length encoding. Signed int value. These more efficiently
+    /// encode negative numbers than regular int32s.
     Sint32,
+    /// Protobuf sint64
+    ///
+    /// # Remarks
+    ///
+    /// Uses variable-length encoding. Signed int value. These more efficiently
+    /// encode negative numbers than regular int32s.
     Sint64,
+    /// Protobuf bool
     Bool,
+    /// Protobuf enum (holds the enum name)
     Enum(String),
+    /// Protobuf fixed64
+    ///
+    /// # Remarks
+    ///
+    /// Always eight bytes. More efficient than uint64 if values are often greater than 2^56.
     Fixed64,
+    /// Protobuf sfixed64
+    ///
+    /// # Remarks
+    ///
+    /// Always eight bytes.
     Sfixed64,
+    /// Protobuf double
     Double,
+    /// Protobuf string
+    ///
+    /// # Remarks
+    ///
+    /// A string must always contain UTF-8 encoded or 7-bit ASCII text.
     String_,
+    /// Protobuf bytes
+    ///
+    /// # Remarks
+    ///
+    /// May contain any arbitrary sequence of bytes.
     Bytes,
+    /// Protobut message (holds the message name)
     Message(String),
+    /// Protobut fixed32
+    ///
+    /// # Remarks
+    ///
+    /// Always four bytes. More efficient than uint32 if values are often greater than 2^28.
     Fixed32,
+    /// Protobut sfixed32
+    ///
+    /// # Remarks
+    ///
+    /// Always four bytes.
     Sfixed32,
+    /// Protobut float
     Float,
+    /// Protobut map
     Map(Box<(FieldType, FieldType)>),
 }
 
+/// A Protobuf Field
 #[derive(Debug, Clone)]
 pub struct Field {
+    /// Field name
     pub name: String,
+    /// Field `Frequency`
     pub frequency: Frequency,
+    /// Field type
     pub typ: FieldType,
+    /// Tag number
     pub number: i32,
+    /// Default value for the field
     pub default: Option<String>,
+    /// Packed property for repeated fields
     pub packed: Option<bool>,
-    pub boxed: bool,
+    /// Is the field deprecated
     pub deprecated: bool,
 }
 
+/// A protobuf message
 #[derive(Debug, Clone, Default)]
 pub struct Message {
+    /// Message name
     pub name: String,
+    /// Message `Field`s
     pub fields: Vec<Field>,
+    /// Message `OneOf`s
     pub oneofs: Vec<OneOf>,
+    /// Message reserved numbers
     pub reserved_nums: Option<Vec<i32>>,
+    /// Message reserved names
     pub reserved_names: Option<Vec<String>>,
-    pub imported: bool,
-    pub package: String,        // package from imports + nested items
-    pub messages: Vec<Message>, // nested messages
-    pub enums: Vec<Enumerator>, // nested enums
-    pub module: String,         // 'package' corresponding to actual generated Rust module
+    /// Nested messages
+    pub messages: Vec<Message>,
+    /// Nested enums
+    pub enums: Vec<Enumerator>,
 }
 
+/// A protobuf enumerator field
+#[derive(Debug, Clone)]
+pub struct EnumVariant {
+    /// enum variant name
+    pub name: String,
+    /// enum variant number
+    pub number: i32,
+}
+
+/// A protobuf enumerator
 #[derive(Debug, Clone)]
 pub struct Enumerator {
+    /// enum name
     pub name: String,
-    pub fields: Vec<(String, i32)>,
-    pub imported: bool,
-    pub package: String,
-    pub module: String,
+    /// enum variants
+    pub variants: Vec<EnumVariant>,
 }
 
+/// A OneOf
 #[derive(Debug, Clone, Default)]
 pub struct OneOf {
+    /// OneOf name
     pub name: String,
+    /// OneOf fields
     pub fields: Vec<Field>,
-    pub package: String,
-    pub module: String,
-    pub imported: bool,
 }
 
+/// A File descriptor representing a whole .proto file
 #[derive(Debug, Default, Clone)]
 pub struct FileDescriptor {
+    /// Imports
     pub import_paths: Vec<PathBuf>,
+    /// Package
     pub package: String,
+    /// Protobuf Syntax
     pub syntax: Syntax,
+    /// Top level messages
     pub messages: Vec<Message>,
+    /// Enums
     pub enums: Vec<Enumerator>,
-    pub module: String,
 }
 
 impl FileDescriptor {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,14 +66,14 @@ pub enum FieldType {
     ///
     /// # Remarks
     ///
-    /// Uses variable-length encoding. Signed int value. These more efficiently
+    /// Uses ZigZag variable-length encoding. Signed int value. These more efficiently
     /// encode negative numbers than regular int32s.
     Sint32,
     /// Protobuf sint64
     ///
     /// # Remarks
     ///
-    /// Uses variable-length encoding. Signed int value. These more efficiently
+    /// Uses ZigZag variable-length encoding. Signed int value. These more efficiently
     /// encode negative numbers than regular int32s.
     Sint64,
     /// Protobuf bool
@@ -99,7 +99,7 @@ pub enum FieldType {
     /// # Remarks
     ///
     /// A string must always contain UTF-8 encoded or 7-bit ASCII text.
-    String_,
+    String,
     /// Protobuf bytes
     ///
     /// # Remarks

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,6 @@ extern crate nom;
 
 mod parser;
 
-use std::path::PathBuf;
 use std::ops::Range;
 use parser::file_descriptor;
 
@@ -161,6 +160,8 @@ pub struct Message {
     /// Message `OneOf`s
     pub oneofs: Vec<OneOf>,
     /// Message reserved numbers
+    ///
+    /// TODO: use RangeInclusive once stable
     pub reserved_nums: Vec<Range<i32>>,
     /// Message reserved names
     pub reserved_names: Vec<String>,
@@ -201,7 +202,7 @@ pub struct OneOf {
 #[derive(Debug, Default, Clone)]
 pub struct FileDescriptor {
     /// Imports
-    pub import_paths: Vec<PathBuf>,
+    pub import_paths: Vec<String>,
     /// Package
     pub package: String,
     /// Protobuf Syntax

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,9 +21,9 @@ impl Default for Syntax {
     }
 }
 
-/// A field frequency
+/// A field rule
 #[derive(Debug, Clone)]
-pub enum Frequency {
+pub enum Rule {
     /// A well-formed message can have zero or one of this field (but not more than one).
     Optional,
     /// This field can be repeated any number of times (including zero) in a well-formed message.
@@ -131,8 +131,8 @@ pub enum FieldType {
 pub struct Field {
     /// Field name
     pub name: String,
-    /// Field `Frequency`
-    pub frequency: Frequency,
+    /// Field `Rule`
+    pub rule: Rule,
     /// Field type
     pub typ: FieldType,
     /// Tag number

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -129,6 +129,7 @@ pub enum FieldType {
     Float,
     /// Protobut map
     Map(Box<(FieldType, FieldType)>),
+    /// TODO: Groups (even if deprecated)
 }
 
 /// A Protobuf Field

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,7 +1,7 @@
 use std::str;
 use std::path::{Path, PathBuf};
 
-use super::{EnumVariant, Enumerator, Field, FieldType, FileDescriptor, Frequency, Message, OneOf,
+use super::{EnumVariant, Enumerator, Field, FieldType, FileDescriptor, Rule, Message, OneOf,
             Syntax};
 use nom::{digit, hex_digit, multispace};
 
@@ -123,10 +123,10 @@ named!(
 );
 
 named!(
-    frequency<Frequency>,
-    alt!(tag!("optional") => { |_| Frequency::Optional } |
-            tag!("repeated") => { |_| Frequency::Repeated } |
-            tag!("required") => { |_| Frequency::Required } )
+    rule<Rule>,
+    alt!(tag!("optional") => { |_| Rule::Optional } |
+            tag!("repeated") => { |_| Rule::Repeated } |
+            tag!("required") => { |_| Rule::Required } )
 );
 
 named!(
@@ -173,11 +173,11 @@ named!(
 named!(
     message_field<Field>,
     do_parse!(
-        frequency: opt!(frequency) >> many0!(br) >> typ: field_type >> many1!(br) >> name: word
+        rule: opt!(rule) >> many0!(br) >> typ: field_type >> many1!(br) >> name: word
             >> many0!(br) >> tag!("=") >> many0!(br) >> number: integer >> many0!(br)
             >> key_vals: many0!(key_val) >> tag!(";") >> (Field {
             name: name,
-            frequency: frequency.unwrap_or(Frequency::Optional),
+            rule: rule.unwrap_or(Rule::Optional),
             typ: typ,
             number: number,
             default: key_vals

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -239,8 +239,8 @@ named!(
             for e in events {
                 match e {
                     MessageEvent::Field(f) => msg.fields.push(f),
-                    MessageEvent::ReservedNums(r) => msg.reserved_nums = Some(r),
-                    MessageEvent::ReservedNames(r) => msg.reserved_names = Some(r),
+                    MessageEvent::ReservedNums(r) => msg.reserved_nums = r,
+                    MessageEvent::ReservedNames(r) => msg.reserved_names = r,
                     MessageEvent::Message(m) => msg.messages.push(m),
                     MessageEvent::Enumerator(e) => msg.enums.push(e),
                     MessageEvent::OneOf(o) => msg.oneofs.push(o),

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -2,8 +2,7 @@ use std::str;
 use std::path::{Path, PathBuf};
 use std::ops::Range;
 
-use super::{EnumValue, Enumeration, Field, FieldType, FileDescriptor, Rule, Message, OneOf,
-            Syntax};
+use super::{EnumValue, Enumeration, Field, FieldType, FileDescriptor, Message, OneOf, Rule, Syntax};
 use nom::{digit, hex_digit, multispace};
 
 fn is_word(b: u8) -> bool {
@@ -97,8 +96,7 @@ named!(
                 separated_list!(
                     do_parse!(many0!(br) >> tag!(",") >> many0!(br) >> (())),
                     alt!(num_range | integer => { |i| i..(i + 1) })
-                ) >> many0!(br) >> tag!(";")
-            >> (nums)
+                ) >> many0!(br) >> tag!(";") >> (nums)
     )
 );
 
@@ -174,8 +172,8 @@ named!(
 named!(
     message_field<Field>,
     do_parse!(
-        rule: opt!(rule) >> many0!(br) >> typ: field_type >> many1!(br) >> name: word
-            >> many0!(br) >> tag!("=") >> many0!(br) >> number: integer >> many0!(br)
+        rule: opt!(rule) >> many0!(br) >> typ: field_type >> many1!(br) >> name: word >> many0!(br)
+            >> tag!("=") >> many0!(br) >> number: integer >> many0!(br)
             >> key_vals: many0!(key_val) >> tag!(";") >> (Field {
             name: name,
             rule: rule.unwrap_or(Rule::Optional),

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,5 +1,6 @@
 use std::str;
 use std::path::{Path, PathBuf};
+use std::ops::Range;
 
 use super::{EnumVariant, Enumerator, Field, FieldType, FileDescriptor, Rule, Message, OneOf,
             Syntax};
@@ -81,23 +82,23 @@ named!(
 );
 
 named!(
-    num_range<Vec<i32>>,
+    num_range<Range<i32>>,
     do_parse!(
         from_: integer >> many1!(br) >> tag!("to") >> many1!(br) >> to_: integer
-            >> ((from_..(to_ + 1)).collect())
+            >> (from_..(to_ + 1))
     )
 );
 
 named!(
-    reserved_nums<Vec<i32>>,
+    reserved_nums<Vec<Range<i32>>>,
     do_parse!(
         tag!("reserved") >> many1!(br)
             >> nums:
                 separated_list!(
                     do_parse!(many0!(br) >> tag!(",") >> many0!(br) >> (())),
-                    alt!(num_range | integer => { |i| vec![i] })
+                    alt!(num_range | integer => { |i| i..(i + 1) })
                 ) >> many0!(br) >> tag!(";")
-            >> (nums.into_iter().flat_map(|v| v.into_iter()).collect())
+            >> (nums)
     )
 );
 
@@ -201,7 +202,7 @@ enum MessageEvent {
     Message(Message),
     Enumerator(Enumerator),
     Field(Field),
-    ReservedNums(Vec<i32>),
+    ReservedNums(Vec<Range<i32>>),
     ReservedNames(Vec<String>),
     OneOf(OneOf),
     Ignore,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -142,7 +142,7 @@ named!(
             tag!("fixed64") => { |_| FieldType::Fixed64 } |
             tag!("sfixed64") => { |_| FieldType::Sfixed64 } |
             tag!("bool") => { |_| FieldType::Bool } |
-            tag!("string") => { |_| FieldType::String_ } |
+            tag!("string") => { |_| FieldType::String } |
             tag!("bytes") => { |_| FieldType::Bytes } |
             tag!("float") => { |_| FieldType::Float } |
             tag!("double") => { |_| FieldType::Double } |
@@ -437,7 +437,7 @@ mod test {
             assert_eq!(1, mess.fields.len());
             match mess.fields[0].typ {
                 FieldType::Map(ref f) => match &**f {
-                    &(FieldType::String_, FieldType::Int32) => (),
+                    &(FieldType::String, FieldType::Int32) => (),
                     ref f => panic!("Expecting Map<String, Int32> found {:?}", f),
                 },
                 ref f => panic!("Expecting map, got {:?}", f),


### PR DESCRIPTION
- remove higher level fields (boxed, imported, module ...): these fields are
  used in quick-protobuf but the final implementation may not need them
- document all structs