### PR TITLE
Rewrite parser without nom

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,9 @@
 [package]
 name = "protobuf-parser"
 version = "0.1.3"
-description = "A nom-based parser for .proto files"
+description = "A parser for .proto files"
 authors = ["Johann Tuffe <tafia973@gmail.com>"]
 keywords = ["protobuf", "parser"]
 license = "MIT"
 readme = "README.md" 
 repository = "https://github.com/tafia/protobuf-parser"
-
-[dependencies]
-nom = "3.2.1"

--- a/examples/test_against_protobuf_protos.rs
+++ b/examples/test_against_protobuf_protos.rs
@@ -1,0 +1,27 @@
+extern crate protobuf_parser;
+
+use std::path::Path;
+use std::fs;
+use std::env;
+use std::io::Read;
+
+fn parse_recursively(path: &Path) {
+    let file_name = path.file_name().expect("file_name").to_str().expect("to_str");
+    if path.is_dir() {
+        for entry in fs::read_dir(path).expect("read_dir") {
+            parse_recursively(&entry.expect("entry").path());
+        }
+    } else if file_name.ends_with(".proto") {
+        println!("checking {}", path.display());
+        let mut content = String::new();
+        fs::File::open(path).expect("open").read_to_string(&mut content).expect("read");
+        protobuf_parser::FileDescriptor::parse(&content).expect("parse");
+    }
+}
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+    assert_eq!(2, args.len());
+    // arg[1] is a path to protobuf tree
+    parse_recursively(&Path::new(&args[1]));
+}


### PR DESCRIPTION
I was struggling with nom lack of good diagnostic messages, and I
decided that it's easier to rewrite parser without nom.

The new parser in particular properly reports error location (line and
column) which was a big pain of old parser (fixes #13).

New parser correctly accepts syntax which is specified in `syntax = ...` header.

New parser successfully parses (although doesn't check for correctness)
all protobuf `.proto` files:

```
cargo run --example test_against_protobuf_protos ~/devel/protobuf/
```